### PR TITLE
Allow for (tool-driven) development workflows

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -1,52 +1,52 @@
 #!/bin/bash
 
 while (($# > 0))
-	do
-	declare Option="$1"
-    declare Val="$2"
-    
-    echo Option: $Option
-    echo Val: $Val
+    do
+    declare Option="$1"
+    declare Value="$2"
+
     case $Option in
     --rom)
-        if [[ "$Val" != "icosa" && "$Val" != "foster" && "$Val" != "foster_tab" ]]
+        if [[ "$Value" != "icosa" && "$Value" != "foster" && "$Value" != "foster_tab" ]]
             then
             echo "Invalid rom name. Expecting icosa | foster | foster_tab"
             exit 1
         fi
-        declare ROM_NAME="$Val"
+        declare ROM_NAME="$Value"
         shift
         shift
         ;;
+
     --rom-type)
-        if [[ "$Val" != "zip" && "$Val" != "images" ]]
+        if [[ "$Value" != "zip" && "$Value" != "images" ]]
             then
             echo "Invalid rom type. Expecting images | zip"
             exit 1
         fi
-        declare ROM_TYPE="$Val"
+        declare ROM_TYPE="$Value"
         shift
         shift
         ;;
+
+    --flags)
+        if [ -z ${Value##*--*} ]
+            then
+            echo "Flags must come last and the arguments must not be empty."
+            exit 1
+        fi
+        declare FLAGS="$Value"
+        shift
+        shift
+        ;;
+
     *)
-    echo "Unknown option. Ignoring $Option."
-    shift
-    ;;
+        echo "Unknown option. Ignoring $Option."
+        shift
+        ;;
+
     esac
 done
-           
 
-if [[ -z $ROM_TYPE ]]
-    then
-    echo "No rom type provided. Assuming zip"
-    declare ROM_TYPE="zip"
-fi
-
-if [[ -z $ROM_NAME ]]
-    then
-    echo "No rom name provided. Assuming icosa"
-    declare ROM_NAME="icosa"
-fi
-    
 ./create-image.sh
-ROM_NAME=$ROM_NAME ROM_TYPE=$ROM_TYPE ./build-in-docker.sh
+
+ROM_NAME=${ROM_NAME:-icosa} ROM_TYPE=${ROM_TYPE:-zip} FLAGS=${FLAGS:-""} ./build-in-docker.sh

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
 
-if [[ -z $ROM_NAME ]]
+if [ -z $ROM_NAME ];
 then
     echo "Missing ROM_NAME env variable. Expected icosa | foster | foster_tab"
     exit 1
+else
+    echo "ROM name: $ROM_NAME"
 fi
 
-if [[ -z $ROM_TYPE ]]
+if [ -z $ROM_TYPE ];
 then
     echo "Missing ROM_TYPE env variable. Expected zip | images"
     exit 1
+else
+    echo "ROM type: $ROM_TYPE"
+fi
+
+if [ -n $FLAGS ];
+then
+    echo "Flags: $FLAGS"
 fi
 
 mkdir -p ./android/lineage
 echo Building $ROM_NAME
-docker run --rm -ti -e ROM_NAME=$ROM_NAME -e ROM_TYPE=$ROM_TYPE -v "$PWD"/android:/root/android pablozaiden/switchroot-android-build
+docker run --rm -ti -e ROM_NAME=$ROM_NAME -e ROM_TYPE=$ROM_TYPE -e FLAGS=${FLAGS:-""} -v "$PWD"/android:/root/android pablozaiden/switchroot-android-build

--- a/docker-scripts/default-command.sh
+++ b/docker-scripts/default-command.sh
@@ -1,18 +1,17 @@
 #!/bin/bash
 
-if [ "$(ls -A ./android/lineage)" ]; then
+if [ -d ./android/lineage ]; then
     echo "Sources found. Skipping..."
 else
     echo "Getting sources..."
-    ACTION="default"
     ./get-sources.sh
 fi
 
-if [ "$ACTION" != "noupdate" ]; then
+if [ -n ${FLAGS##*noupdate*} ]; then
     ./reset-changes-update-sources.sh
     ./repopic-and-patch.sh
 fi
 
-if [ "$ACTION" != "nobuild" ]; then
+if [ -n ${FLAGS##*nobuild*} ]; then
     ./build.sh
 fi

--- a/docker-scripts/default-command.sh
+++ b/docker-scripts/default-command.sh
@@ -4,9 +4,15 @@ if [ "$(ls -A ./android/lineage)" ]; then
     echo "Sources found. Skipping..."
 else
     echo "Getting sources..."
+    ACTION="default"
     ./get-sources.sh
 fi
 
-./reset-changes-update-sources.sh
-./repopic-and-patch.sh
-./build.sh
+if [ "$ACTION" != "noupdate" ]; then
+    ./reset-changes-update-sources.sh
+    ./repopic-and-patch.sh
+fi
+
+if [ "$ACTION" != "nobuild" ]; then
+    ./build.sh
+fi


### PR DESCRIPTION
By using a var to control whether to update or build we can have development workflows such as sync - patch - build driven by a local tool such a script.