### PR TITLE
Initial support for time-travel and forcing clean

### DIFF
--- a/docker-scripts/build.sh
+++ b/docker-scripts/build.sh
@@ -10,9 +10,11 @@ lunch lineage_$ROM_NAME-userdebug
 
 sed -i '/BOARD_KERNEL_IMAGE_NAME := zImage/a BOARD_MKBOOTIMG_ARGS    += --cmdline " "' ~/android/lineage/device/nvidia/foster/BoardConfig.mk
 
+NPROC=$(($(nproc) + 1))
+
 if [ "$ROM_TYPE" == "zip" ]
   then
-  make bacon
+  make -j${NPROC} bacon
 else
-  make bootimage && make vendorimage && make systemimage
+  make -j${NPROC} bootimage && make -j${NPROC} vendorimage && make -j${NPROC} systemimage && make -j${NPROC} recoveryimage
 fi

--- a/docker-scripts/default-command.sh
+++ b/docker-scripts/default-command.sh
@@ -7,9 +7,25 @@ else
     ./get-sources.sh
 fi
 
-if [[ -z $FLAGS || ! -z ${FLAGS##*noupdate*} ]]; then
-    ./reset-changes-update-sources.sh
+if [[ -f /root/android/lineage/.repo/repo/repo ]]; then
+    cp /root/android/lineage/.repo/repo/repo /root/bin/repo
+fi
+
+if [[ -z $FLAGS || ! -z ${FLAGS##*noupdate*} || -z ${FLAGS##*timetravelto*} ]]; then
+    TARGETDATE=$(sed -E 's/.*timetravelto\=((\w|-|\s|\:){1,}).*/\1/g' <<<$FLAGS)
+    
+    if [[ ! -z ${TARGETDATE} ]]; then
+        echo "Target date: ${TARGETDATE}"
+    fi
+
+    ./reset-changes-update-sources.sh ${TARGETDATE}
     ./repopic-and-patch.sh
+fi
+
+if [[ -n $FLAGS && -z ${FLAGS##*forceclean*} ]]; then
+    cd /root/android/lineage
+    make clobber && make clean
+    cd /root
 fi
 
 if [[ -z $FLAGS || ! -z ${FLAGS##*nobuild*} ]]; then

--- a/docker-scripts/get-sources.sh
+++ b/docker-scripts/get-sources.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+NPROC=$(($(nproc) - 1))
+
 cd /root/android/lineage
 repo init -u https://github.com/LineageOS/android.git -b lineage-16.0
-repo sync -j16
+repo sync -j${NPROC}
 
 cd /root/android/lineage/.repo
 git clone https://gitlab.com/switchroot/android/manifest.git local_manifests
-repo sync -j16
+repo sync -j${NPROC}

--- a/docker-scripts/reset-changes-update-sources.sh
+++ b/docker-scripts/reset-changes-update-sources.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+NPROC=$(($(nproc) - 1))
+
 cd /root/android/lineage
-repo forall -c 'git reset --hard'
+repo forall -c "bash -c 'git reset --hard \${1//*/\`git rev-list -1 --before=\${1} @\`}' null ${1}"
 
 cd .repo/local_manifests
 git pull
 
 cd ../..
 
-repo sync -j16
+if [[ -z $1 ]]; then
+    repo sync -j${NPROC}
+fi


### PR DESCRIPTION
Helpers for development workflows. Not documenting it on the frontend script right now in order for us to discuss any needed changes.

Date formats are those supported by Git, as long as it's one contiguous string without spaces (for instance "yesterday" or ISO8601). This limitation may be lifted in the future.